### PR TITLE
Please turn over pypi module rights to Adafruit

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ Adafruit invests time and resources providing this open source code, please supp
 Written by Tony DiCola for Adafruit Industries.
 
 MIT license, all text above must be included in any redistribution
+


### PR DESCRIPTION
Hi hexdump42, because you forked and uploaded this library to pypi, [ladyada and team can't post any updates](https://github.com/adafruit/Adafruit_Python_DHT/issues/77#issuecomment-354342823).

Can you turn over or share the pypi publishing with Adafruit? That way the official library will be able to update in the proper location.